### PR TITLE
Explicitly depend on artifact-source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,21 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>com.atomist</groupId>
+			<artifactId>artifact-source</artifactId>
+			<version>0.14.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-access</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>1.16</version>


### PR DESCRIPTION
It was getting it through Rug.
If you use it directly, depend on it directly.